### PR TITLE
HMA-2551: Change calculation from `canEarnFinalBonus` to `finalBonusS…

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This will returns an object of type `FinalBonusCalculatorResponse`.
 * `totalProjectedSavingsIncludingBonuses: Double`
 * `totalProjectedSavings: Double`
 * `totalProjectedBonuses: Double`
-* `canEarnFinalBonus: Boolean`
+* `finalBonusStatus: String`
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ This will returns an object of type `FinalBonusCalculatorResponse`.
 * `totalProjectedSavingsIncludingBonuses: Double`
 * `totalProjectedSavings: Double`
 * `totalProjectedBonuses: Double`
-* `finalBonusStatus: String`
+* `finalBonusStatus: FinalBonusStatus`
 
 ## Validation
 

--- a/src/commonMain/kotlin/uk/gov/hmrc/helptosavecalculator/FinalBonusTermCalculation.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/helptosavecalculator/FinalBonusTermCalculation.kt
@@ -16,6 +16,7 @@
 package uk.gov.hmrc.helptosavecalculator
 
 import uk.gov.hmrc.helptosavecalculator.models.FinalBonusInput
+import uk.gov.hmrc.helptosavecalculator.models.FinalBonusStatus
 import uk.gov.hmrc.helptosavecalculator.utils.monthsSince
 
 internal class FinalBonusTermCalculation {
@@ -57,10 +58,11 @@ internal class FinalBonusTermCalculation {
         input: FinalBonusInput,
         monthsLeftInScheme: Int,
         additionalSavingsThisMonth: Double
-    ): String {
+    ): FinalBonusStatus {
         val highestPossibleBalance = input.currentBalance + additionalSavingsThisMonth + (monthsLeftInScheme * 50)
-        return if (input.secondTermBonusEstimate > 0.0) "earned" else {
-            if (highestPossibleBalance > input.balanceMustBeMoreThanForBonus) "possibleToEarn" else "cannotEarn"
+        return if (input.secondTermBonusEstimate > 0.0) FinalBonusStatus.EARNED else {
+            if (highestPossibleBalance > input.balanceMustBeMoreThanForBonus)
+                FinalBonusStatus.POSSIBLE_TO_EARN else FinalBonusStatus.CANNOT_EARN
         }
     }
 

--- a/src/commonMain/kotlin/uk/gov/hmrc/helptosavecalculator/FinalBonusTermCalculation.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/helptosavecalculator/FinalBonusTermCalculation.kt
@@ -53,6 +53,17 @@ internal class FinalBonusTermCalculation {
         it > totalProjectedSavings
     } ?: totalProjectedSavings
 
+    fun finalBonusStatus(
+        input: FinalBonusInput,
+        monthsLeftInScheme: Int,
+        additionalSavingsThisMonth: Double
+    ): String {
+        val highestPossibleBalance = input.currentBalance + additionalSavingsThisMonth + (monthsLeftInScheme * 50)
+        return if (input.secondTermBonusEstimate > 0.0) "earned" else {
+            if (highestPossibleBalance > input.balanceMustBeMoreThanForBonus) "possibleToEarn" else "cannotEarn"
+        }
+    }
+
     fun calculateMonthsLeftInScheme(input: FinalBonusInput): Int {
         val thisMonthEndDate = input.thisMonthEndDate.convertToDateTime()
         val secondTermEndDate = input.secondTermEndDate.convertToDateTime()

--- a/src/commonMain/kotlin/uk/gov/hmrc/helptosavecalculator/FinalBonusTermCalculator.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/helptosavecalculator/FinalBonusTermCalculator.kt
@@ -27,7 +27,6 @@ object FinalBonusTermCalculator {
     fun runFinalBonusCalculator(input: FinalBonusInput): FinalBonusCalculatorResponse = calculateFinalBonus(input)
 
     private fun calculateFinalBonus(input: FinalBonusInput): FinalBonusCalculatorResponse {
-        var canEarnFinalBonus = true
         validateUserInput(input.regularPayment)
 
         val monthLeftInScheme = calculation.calculateMonthsLeftInScheme(input)
@@ -45,16 +44,13 @@ object FinalBonusTermCalculator {
         val totalProjectedSavingsIncludingBonuses = calculation.calculateTotalProjectedSavingsIncludeBonuses(
                 totalProjectedSavings,
                 totalProjectedBonuses)
-
-        if (totalProjectedBonuses == 0.0) {
-            canEarnFinalBonus = false
-        }
+        val finalBonusStatus = calculation.finalBonusStatus(input, monthLeftInScheme, additionalSavingsThisMonth)
 
         return FinalBonusCalculatorResponse(
                 totalProjectedSavingsIncludingBonuses,
                 totalProjectedSavings,
                 totalProjectedBonuses,
-                canEarnFinalBonus
+                finalBonusStatus
         )
     }
 

--- a/src/commonMain/kotlin/uk/gov/hmrc/helptosavecalculator/models/CalculatorResponse.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/helptosavecalculator/models/CalculatorResponse.kt
@@ -53,5 +53,5 @@ data class FinalBonusCalculatorResponse(
     val totalProjectedSavingsIncludingBonuses: Double,
     val totalProjectedSavings: Double,
     val totalProjectedBonuses: Double,
-    val canEarnFinalBonus: Boolean
+    val finalBonusStatus: String
 )

--- a/src/commonMain/kotlin/uk/gov/hmrc/helptosavecalculator/models/CalculatorResponse.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/helptosavecalculator/models/CalculatorResponse.kt
@@ -53,5 +53,5 @@ data class FinalBonusCalculatorResponse(
     val totalProjectedSavingsIncludingBonuses: Double,
     val totalProjectedSavings: Double,
     val totalProjectedBonuses: Double,
-    val finalBonusStatus: String
+    val finalBonusStatus: FinalBonusStatus
 )

--- a/src/commonMain/kotlin/uk/gov/hmrc/helptosavecalculator/models/FinalBonusStatus.kt
+++ b/src/commonMain/kotlin/uk/gov/hmrc/helptosavecalculator/models/FinalBonusStatus.kt
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.gov.hmrc.helptosavecalculator.models
+
+enum class FinalBonusStatus {
+    EARNED, POSSIBLE_TO_EARN, CANNOT_EARN
+}

--- a/src/commonTest/kotlin/uk/gov/hmrc/FinalBonusTermCalculationTest.kt
+++ b/src/commonTest/kotlin/uk/gov/hmrc/FinalBonusTermCalculationTest.kt
@@ -153,4 +153,49 @@ class FinalBonusTermCalculationTest {
 
         assertEquals(11, result)
     }
+
+    @Test
+    fun `GIVEN customer already earned final bonus WHEN finalBonusStatus called THEN return earned`() {
+        val input = FinalBonusInput(10.0,
+                0.0,
+                25.0,
+                YearMonthDayInput(2023, 3),
+                YearMonthDayInput(2024, 2, 28),
+                10.0,
+                5.0)
+        val calculation = FinalBonusTermCalculation()
+        val result = calculation.finalBonusStatus(input, 23, 0.0)
+
+        assertEquals("earned", result)
+    }
+
+    @Test
+    fun `GIVEN customer can possibly earn a final bonus WHEN finalBonusStatus called THEN return possibleToEarn`() {
+        val input = FinalBonusInput(10.0,
+                0.0,
+                25.0,
+                YearMonthDayInput(2023, 3),
+                YearMonthDayInput(2024, 2, 28),
+                10.0,
+                0.0)
+        val calculation = FinalBonusTermCalculation()
+        val result = calculation.finalBonusStatus(input, 23, 0.0)
+
+        assertEquals("possibleToEarn", result)
+    }
+
+    @Test
+    fun `GIVEN customer can not earn final bonus WHEN finalBonusStatus called THEN return cannotEarn`() {
+        val input = FinalBonusInput(50.0,
+                0.0,
+                0.0,
+                YearMonthDayInput(2023, 3),
+                YearMonthDayInput(2024, 2, 28),
+                1200.0,
+                0.0)
+        val calculation = FinalBonusTermCalculation()
+        val result = calculation.finalBonusStatus(input, 22, 50.0)
+
+        assertEquals("cannotEarn", result)
+    }
 }

--- a/src/commonTest/kotlin/uk/gov/hmrc/FinalBonusTermCalculationTest.kt
+++ b/src/commonTest/kotlin/uk/gov/hmrc/FinalBonusTermCalculationTest.kt
@@ -19,6 +19,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import uk.gov.hmrc.helptosavecalculator.FinalBonusTermCalculation
 import uk.gov.hmrc.helptosavecalculator.models.FinalBonusInput
+import uk.gov.hmrc.helptosavecalculator.models.FinalBonusStatus
 import uk.gov.hmrc.helptosavecalculator.models.YearMonthDayInput
 
 class FinalBonusTermCalculationTest {
@@ -166,7 +167,7 @@ class FinalBonusTermCalculationTest {
         val calculation = FinalBonusTermCalculation()
         val result = calculation.finalBonusStatus(input, 23, 0.0)
 
-        assertEquals("earned", result)
+        assertEquals(FinalBonusStatus.EARNED, result)
     }
 
     @Test
@@ -181,7 +182,7 @@ class FinalBonusTermCalculationTest {
         val calculation = FinalBonusTermCalculation()
         val result = calculation.finalBonusStatus(input, 23, 0.0)
 
-        assertEquals("possibleToEarn", result)
+        assertEquals(FinalBonusStatus.POSSIBLE_TO_EARN, result)
     }
 
     @Test
@@ -196,6 +197,6 @@ class FinalBonusTermCalculationTest {
         val calculation = FinalBonusTermCalculation()
         val result = calculation.finalBonusStatus(input, 22, 50.0)
 
-        assertEquals("cannotEarn", result)
+        assertEquals(FinalBonusStatus.CANNOT_EARN, result)
     }
 }

--- a/src/commonTest/kotlin/uk/gov/hmrc/FinalBonusTermCalculatorTest.kt
+++ b/src/commonTest/kotlin/uk/gov/hmrc/FinalBonusTermCalculatorTest.kt
@@ -67,7 +67,7 @@ class FinalBonusTermCalculatorTest {
         assertEquals(36.0, calculator.totalProjectedSavingsIncludingBonuses)
         assertEquals(24.0, calculator.totalProjectedSavings)
         assertEquals(12.0, calculator.totalProjectedBonuses)
-        assertEquals(true, calculator.canEarnFinalBonus)
+        assertEquals("possibleToEarn", calculator.finalBonusStatus)
     }
 
     @Test
@@ -84,7 +84,7 @@ class FinalBonusTermCalculatorTest {
         assertEquals(900.0, calculator.totalProjectedSavingsIncludingBonuses)
         assertEquals(600.0, calculator.totalProjectedSavings)
         assertEquals(300.0, calculator.totalProjectedBonuses)
-        assertEquals(true, calculator.canEarnFinalBonus)
+        assertEquals("possibleToEarn", calculator.finalBonusStatus)
     }
 
     @Test
@@ -101,7 +101,7 @@ class FinalBonusTermCalculatorTest {
         assertEquals(1800.0, calculator.totalProjectedSavingsIncludingBonuses)
         assertEquals(1200.0, calculator.totalProjectedSavings)
         assertEquals(600.0, calculator.totalProjectedBonuses)
-        assertEquals(true, calculator.canEarnFinalBonus)
+        assertEquals("possibleToEarn", calculator.finalBonusStatus)
     }
 
     @Test
@@ -118,7 +118,7 @@ class FinalBonusTermCalculatorTest {
         assertEquals(900.0, calculator.totalProjectedSavingsIncludingBonuses)
         assertEquals(600.0, calculator.totalProjectedSavings)
         assertEquals(300.0, calculator.totalProjectedBonuses)
-        assertEquals(true, calculator.canEarnFinalBonus)
+        assertEquals("earned", calculator.finalBonusStatus)
     }
 
     @Test
@@ -135,6 +135,6 @@ class FinalBonusTermCalculatorTest {
         assertEquals(25.0, calculator.totalProjectedSavingsIncludingBonuses)
         assertEquals(25.0, calculator.totalProjectedSavings)
         assertEquals(0.0, calculator.totalProjectedBonuses)
-        assertEquals(false, calculator.canEarnFinalBonus)
+        assertEquals("cannotEarn", calculator.finalBonusStatus)
     }
 }

--- a/src/commonTest/kotlin/uk/gov/hmrc/FinalBonusTermCalculatorTest.kt
+++ b/src/commonTest/kotlin/uk/gov/hmrc/FinalBonusTermCalculatorTest.kt
@@ -21,6 +21,7 @@ import kotlin.test.assertFailsWith
 import uk.gov.hmrc.helptosavecalculator.FinalBonusTermCalculator.runFinalBonusCalculator
 import uk.gov.hmrc.helptosavecalculator.exceptions.InvalidRegularPaymentException
 import uk.gov.hmrc.helptosavecalculator.models.FinalBonusInput
+import uk.gov.hmrc.helptosavecalculator.models.FinalBonusStatus
 import uk.gov.hmrc.helptosavecalculator.models.YearMonthDayInput
 
 class FinalBonusTermCalculatorTest {
@@ -67,7 +68,7 @@ class FinalBonusTermCalculatorTest {
         assertEquals(36.0, calculator.totalProjectedSavingsIncludingBonuses)
         assertEquals(24.0, calculator.totalProjectedSavings)
         assertEquals(12.0, calculator.totalProjectedBonuses)
-        assertEquals("possibleToEarn", calculator.finalBonusStatus)
+        assertEquals(FinalBonusStatus.POSSIBLE_TO_EARN, calculator.finalBonusStatus)
     }
 
     @Test
@@ -84,7 +85,7 @@ class FinalBonusTermCalculatorTest {
         assertEquals(900.0, calculator.totalProjectedSavingsIncludingBonuses)
         assertEquals(600.0, calculator.totalProjectedSavings)
         assertEquals(300.0, calculator.totalProjectedBonuses)
-        assertEquals("possibleToEarn", calculator.finalBonusStatus)
+        assertEquals(FinalBonusStatus.POSSIBLE_TO_EARN, calculator.finalBonusStatus)
     }
 
     @Test
@@ -101,7 +102,7 @@ class FinalBonusTermCalculatorTest {
         assertEquals(1800.0, calculator.totalProjectedSavingsIncludingBonuses)
         assertEquals(1200.0, calculator.totalProjectedSavings)
         assertEquals(600.0, calculator.totalProjectedBonuses)
-        assertEquals("possibleToEarn", calculator.finalBonusStatus)
+        assertEquals(FinalBonusStatus.POSSIBLE_TO_EARN, calculator.finalBonusStatus)
     }
 
     @Test
@@ -118,7 +119,7 @@ class FinalBonusTermCalculatorTest {
         assertEquals(900.0, calculator.totalProjectedSavingsIncludingBonuses)
         assertEquals(600.0, calculator.totalProjectedSavings)
         assertEquals(300.0, calculator.totalProjectedBonuses)
-        assertEquals("earned", calculator.finalBonusStatus)
+        assertEquals(FinalBonusStatus.EARNED, calculator.finalBonusStatus)
     }
 
     @Test
@@ -135,6 +136,6 @@ class FinalBonusTermCalculatorTest {
         assertEquals(25.0, calculator.totalProjectedSavingsIncludingBonuses)
         assertEquals(25.0, calculator.totalProjectedSavings)
         assertEquals(0.0, calculator.totalProjectedBonuses)
-        assertEquals("cannotEarn", calculator.finalBonusStatus)
+        assertEquals(FinalBonusStatus.CANNOT_EARN, calculator.finalBonusStatus)
     }
 }


### PR DESCRIPTION
…tatus`.

- Now return a enum of 3 possible status earned/possibleToEarn/cannotEarn.